### PR TITLE
chore(deps):updated `preact` dependency

### DIFF
--- a/packages/splunk-3D-graph-network-topology-viz/appserver/static/visualizations/3d_graph_network_topology_viz/package-lock.json
+++ b/packages/splunk-3D-graph-network-topology-viz/appserver/static/visualizations/3d_graph_network_topology_viz/package-lock.json
@@ -1142,6 +1142,16 @@
         "node": ">=12"
       }
     },
+    "node_modules/float-tooltip/node_modules/preact": {
+      "version": "10.28.4",
+      "resolved": "https://registry.npmjs.org/preact/-/preact-10.28.4.tgz",
+      "integrity": "sha512-uKFfOHWuSNpRFVTnljsCluEFq57OKT+0QdOiQo8XWnQ/pSvg7OpX5eNOejELXJMWy+BwM2nobz0FkvzmnpCNsQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/preact"
+      }
+    },
     "node_modules/force-graph": {
       "version": "1.51.1",
       "resolved": "https://registry.npmjs.org/force-graph/-/force-graph-1.51.1.tgz",
@@ -1544,15 +1554,6 @@
       },
       "engines": {
         "node": ">=10"
-      }
-    },
-    "node_modules/preact": {
-      "version": "10.27.2",
-      "resolved": "https://registry.npmjs.org/preact/-/preact-10.27.2.tgz",
-      "integrity": "sha512-5SYSgFKSyhCbk6SrXyMpqjb5+MQBgfvEKE/OC+PujcY34sOpqtr+0AZQtPYx5IA6VxynQ7rUPCtKzyovpj9Bpg==",
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/preact"
       }
     },
     "node_modules/randombytes": {

--- a/packages/splunk-3D-graph-network-topology-viz/appserver/static/visualizations/3d_graph_network_topology_viz/package.json
+++ b/packages/splunk-3D-graph-network-topology-viz/appserver/static/visualizations/3d_graph_network_topology_viz/package.json
@@ -28,7 +28,8 @@
       "lodash-es": "^4.17.23"
     },
     "force-graph": {
-      "lodash-es": "^4.17.23"
+      "lodash-es": "^4.17.23",
+      "preact": ">=10.27.3"
     }
   }
 }


### PR DESCRIPTION
In reference to JIRA ticket [VULN-63697](https://splunk.atlassian.net/browse/VULN-63697):
- Fixes [#31](https://github.com/splunk/splunk-3D-graph-network-topology-viz/security/dependabot/31)
